### PR TITLE
Update typo in 4_quantum_circuit_properties.ipynb

### DIFF
--- a/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
+++ b/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
@@ -746,7 +746,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This simple example is meant to illustrate a very important point: **When running circuits on actual quantum devices, the circuit that gets run is in general not the same circuit that you constructed**.  In addition, the depth of that new circuit is likely to me larger, and in some cases much larger, than the original one.  Fortunately, there are often times where one can reduce this overhead through smart circuit rewriting toolchains."
+    "This simple example is meant to illustrate a very important point: **When running circuits on actual quantum devices, the circuit that gets run is in general not the same circuit that you constructed**.  In addition, the depth of that new circuit is likely to be larger, and in some cases much larger, than the original one.  Fortunately, there are often times where one can reduce this overhead through smart circuit rewriting toolchains."
    ]
   },
   {


### PR DESCRIPTION
Small typo "likely to me larger" -> "likely to be larger"

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


