### PR TITLE
Update test_tutorials.py docstring to match NOTEBOOK_PATH's default value

### DIFF
--- a/utils/test/test_tutorials.py
+++ b/utils/test/test_tutorials.py
@@ -20,8 +20,8 @@
 """Helper for running the notebooks as unit tests.
 
 Convenience script for running the notebooks as individual `unittest` tests
-using the standard Python facilites. By default, only the notebooks under
-`reference/` are automatically discovered (can be modified via the
+using the standard Python facilites. By default, all notebooks under
+`qiskit/` are automatically discovered (can be modified via the
 `NOTEBOOK_PATH` variable).
 
 The test can be run by using the regular unittest facilities from the root

--- a/utils/test/test_tutorials.py
+++ b/utils/test/test_tutorials.py
@@ -56,7 +56,7 @@ TIMEOUT = os.getenv('TIMEOUT', 6000)
 # Jupyter kernel to execute the notebook in.
 JUPYTER_KERNEL = os.getenv('JUPYTER_KERNEL', 'python3')
 # Glob expression for discovering the notebooks.
-NOTEBOOK_PATH = os.getenv('NOTEBOOK_PATH', 'reference/**/*.ipynb')
+NOTEBOOK_PATH = os.getenv('NOTEBOOK_PATH', 'qiskit/**/*.ipynb')
 
 
 # Retrieve the notebooks recursively.

--- a/utils/test/test_tutorials.py
+++ b/utils/test/test_tutorials.py
@@ -56,7 +56,7 @@ TIMEOUT = os.getenv('TIMEOUT', 6000)
 # Jupyter kernel to execute the notebook in.
 JUPYTER_KERNEL = os.getenv('JUPYTER_KERNEL', 'python3')
 # Glob expression for discovering the notebooks.
-NOTEBOOK_PATH = os.getenv('NOTEBOOK_PATH', 'qiskit/**/*.ipynb')
+NOTEBOOK_PATH = os.getenv('NOTEBOOK_PATH', 'reference/**/*.ipynb')
 
 
 # Retrieve the notebooks recursively.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes issue #824. 

### Details and comments

Changes `NOTEBOOK_PATH` from `qiskit/**/*.ipynb` to `reference/**/*.ipynb` in order to satisfy the documentation.

Rather than editing the pydoc, this solution was chosen so that unit tests could be performed only on a selected number of notebooks.
