### PR TITLE
fixing misspelling of 'tensor' in 'getting_started_with_qiskit_terra'

### DIFF
--- a/qiskit/basics/getting_started_with_qiskit_terra.ipynb
+++ b/qiskit/basics/getting_started_with_qiskit_terra.ipynb
@@ -205,7 +205,7 @@
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
     "\n",
-    "When representing the state of a multi-qubit system, the tensor order used in qiskit is different than that use in most physics textbooks. Suppose there are $n$ qubits, and qubit $j$ is labeled as $Q_{j}$. In most textbooks (such as Nielsen and Chuang's \"Quantum Computation and Information\"), the basis vectors for the $n$-qubit state space would be labeled as $Q_{0}\\otimes Q_{1} \\otimes \\cdots \\otimes Q_{n}$. **This is not the ordering used by qiskit!** Instead, qiskit uses an ordering in which the $n^{\\mathrm{th}}$ qubit is on the _left_ side of the tesnsor product, so that the basis vectors are labeled as  $Q_n\\otimes \\cdots  \\otimes  Q_1\\otimes Q_0$.\n",
+    "When representing the state of a multi-qubit system, the tensor order used in qiskit is different than that use in most physics textbooks. Suppose there are $n$ qubits, and qubit $j$ is labeled as $Q_{j}$. In most textbooks (such as Nielsen and Chuang's \"Quantum Computation and Information\"), the basis vectors for the $n$-qubit state space would be labeled as $Q_{0}\\otimes Q_{1} \\otimes \\cdots \\otimes Q_{n}$. **This is not the ordering used by qiskit!** Instead, qiskit uses an ordering in which the $n^{\\mathrm{th}}$ qubit is on the _left_ side of the tensor product, so that the basis vectors are labeled as  $Q_n\\otimes \\cdots  \\otimes  Q_1\\otimes Q_0$.\n",
     "\n",
     "For example, if qubit zero is in state 0, qubit 1 is in state 0, and qubit 2 is in state 1, qiskit would represent this state as $|100\\rangle$, whereas most physics textbooks would represent it as $|001\\rangle$.\n",
     "\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes. (N/A; just a docs fix)
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `getting_started_with_qiskit_terra` notebook contains a misspelling of the word 'tensor'. This PR simply fixes that.

### Details and comments

N/A
