### PR TITLE
Fix misc. typos and hyphenate "[number]-qubit".

### DIFF
--- a/qiskit/advanced/aer/1_aer_provider.ipynb
+++ b/qiskit/advanced/aer/1_aer_provider.ipynb
@@ -219,7 +219,7 @@
     "* The initial statevector must be a valid quantum state $|\\langle\\psi|\\psi\\rangle|=1$. If not, an exception will be raised. \n",
     "* The simulator supports this option directly for efficiency, but it can also be unrolled to standard gates for execution on actual devices.\n",
     "\n",
-    "We now demonstrate this functionality by setting the simulator to be initialized in the the final Bell-state of the previous example:"
+    "We now demonstrate this functionality by setting the simulator to be initialized in the final Bell-state of the previous example:"
    ]
   },
   {

--- a/qiskit/advanced/aer/4_custom_gate_noise.ipynb
+++ b/qiskit/advanced/aer/4_custom_gate_noise.ipynb
@@ -425,7 +425,7 @@
    "source": [
     "### Noisy circuit execution\n",
     "\n",
-    "Finally, let's now simulate it with our custom noise model. Since there is a small amplitude damping error on the two qubit gates we expect small additional peaks for the 01 and 10 outcome probabilities."
+    "Finally, let's now simulate it with our custom noise model. Since there is a small amplitude damping error on the two-qubit gates we expect small additional peaks for the 01 and 10 outcome probabilities."
    ]
   },
   {

--- a/qiskit/advanced/aqua/chemistry/dissociation_profile_of_molecule.ipynb
+++ b/qiskit/advanced/aqua/chemistry/dissociation_profile_of_molecule.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "### Introduction\n",
     "\n",
-    "One of the most compelling possibilities of quantum computation is the the simulation of other quantum systems. Quantum simulation of quantum systems encompasses a wide range of tasks, including most significantly:\n",
+    "One of the most compelling possibilities of quantum computation is the simulation of other quantum systems. Quantum simulation of quantum systems encompasses a wide range of tasks, including most significantly:\n",
     "    \n",
     "1. Simulation of the time evolution of quantum systems.\n",
     "\n",

--- a/qiskit/advanced/aqua/linear_systems_of_equations.ipynb
+++ b/qiskit/advanced/aqua/linear_systems_of_equations.ipynb
@@ -359,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Compared to the the first example, the circuit depth is increased approximately by a factor of 6"
+    "Compared to the first example, the circuit depth is increased approximately by a factor of 6"
    ]
   },
   {

--- a/qiskit/advanced/ignis/1b_calibrating_a_two_qubit_gate.ipynb
+++ b/qiskit/advanced/ignis/1b_calibrating_a_two_qubit_gate.ipynb
@@ -20,7 +20,7 @@
     }
    },
    "source": [
-    "# Calibrating a two qubit gate"
+    "# Calibrating a two-qubit gate"
    ]
   },
   {

--- a/qiskit/advanced/ignis/5a_randomized_benchmarking.ipynb
+++ b/qiskit/advanced/ignis/5a_randomized_benchmarking.ipynb
@@ -628,7 +628,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The **two qubit Clifford gate error** gives measured errors in the basis gates that were used to construct the Clifford. \n",
+    "The **two-qubit Clifford gate error** gives measured errors in the basis gates that were used to construct the Clifford. \n",
     "It assumes that the error in the underlying gates is depolarizing. It outputs the error per a 2-qubit Clifford.\n",
     "\n",
     "The input to this function is:\n",
@@ -800,7 +800,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We count again the number of **gates per Clifford** as before, and calculate the **two qubit Clifford gate error**, using the predicted primitive gate errors from the coherence limit."
+    "We count again the number of **gates per Clifford** as before, and calculate the **two-qubit Clifford gate error**, using the predicted primitive gate errors from the coherence limit."
    ]
   },
   {

--- a/qiskit/advanced/ignis/6a_state_tomography.ipynb
+++ b/qiskit/advanced/ignis/6a_state_tomography.ipynb
@@ -463,7 +463,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, we have a three qubit system where one of the qubits will be an ancilla for performing state tomography, i.e. only perform tomography when the third qubit is in the state \"1\". The circuit is setup in such a way that after conditional tomography we will get a Bell state on the first two qubits.\n",
+    "In this example, we have a three-qubit system where one of the qubits will be an ancilla for performing state tomography, i.e. only perform tomography when the third qubit is in the state \"1\". The circuit is setup in such a way that after conditional tomography we will get a Bell state on the first two qubits.\n",
     "\n",
     "First make a 3Q GHZ state with no classical measurements."
    ]

--- a/qiskit/advanced/terra/1_advanced_circuits.ipynb
+++ b/qiskit/advanced/terra/1_advanced_circuits.ipynb
@@ -678,7 +678,7 @@
     "              backend=BasicAer.get_backend('qasm_simulator'),\n",
     "              parameter_binds=[{theta: theta_val} for theta_val in theta_range])\n",
     "\n",
-    "# Note: Bind labels are not presrved in executed experiments.\n",
+    "# Note: Bind labels are not preserved in executed experiments.\n",
     "counts = [job.result().get_counts(i) for i in range(len(job.result().results))]\n"
    ]
   },

--- a/qiskit/advanced/terra/4_transpiler_passes_and_passmanager.ipynb
+++ b/qiskit/advanced/terra/4_transpiler_passes_and_passmanager.ipynb
@@ -1120,7 +1120,7 @@
    "source": [
     "## Transpiler Logging <a name='logging'></a>\n",
     "\n",
-    "Due to the complexity of the internal operations that the transpiler is performing it's likely that you'll end up in a situation where you'd like to debug an issue or just understand more of what is happening inside the transpiler when you call it. To facilitate this the transpiler emits log messages as part of it's normal operation. This logging uses the Python standard library `logging` module to emit the log messages. Python's standard logging was used because it allows Qiskit-Terra's logging to integrate in a standard way with other applications and libraries.\n",
+    "Due to the complexity of the internal operations that the transpiler is performing it's likely that you'll end up in a situation where you'd like to debug an issue or just understand more of what is happening inside the transpiler when you call it. To facilitate this the transpiler emits log messages as part of its normal operation. This logging uses the Python standard library `logging` module to emit the log messages. Python's standard logging was used because it allows Qiskit-Terra's logging to integrate in a standard way with other applications and libraries.\n",
     "\n",
     "For a more thorough introduction to Python logging refer to the [official documentation](https://docs.python.org/3/library/logging.html) and the tutorials and cookbook linked off of there."
    ]
@@ -1140,7 +1140,7 @@
    "source": [
     "### Configuring Python Standard Library Logging\n",
     "\n",
-    "By default Python Stadnard Logging only prints log messages at the `WARNING`, `ERROR`, or `CRITICAL` log levels.\n",
+    "By default Python Standard Logging only prints log messages at the `WARNING`, `ERROR`, or `CRITICAL` log levels.\n",
     "Since none of the logs emitted by the transpiler use these log levels (they're all informative) you need to configure logging.\n",
     "\n",
     "The simplest way to do this is to just run:"

--- a/qiskit/advanced/terra/5_pulse_schedules.ipynb
+++ b/qiskit/advanced/terra/5_pulse_schedules.ipynb
@@ -340,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All `Command`s have a `duration` attribute. This may be fixed as for the case of the `FrameChange` having zero duration, or dependent on the command as is the case for the `SamplePulse` who's duration is defined by the number of samples in the pulse."
+    "All `Command`s have a `duration` attribute. This may be fixed as for the case of the `FrameChange` having zero duration, or dependent on the command as is the case for the `SamplePulse` whose duration is defined by the number of samples in the pulse."
    ]
   },
   {
@@ -442,7 +442,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Instructions` can also be plotted"
+    "`Instructions` can also be plotted."
    ]
   },
   {

--- a/qiskit/advanced/terra/5_pulse_schedules.ipynb
+++ b/qiskit/advanced/terra/5_pulse_schedules.ipynb
@@ -74,7 +74,7 @@
     "As all channels correspond to physical channels on a device, they have an `index` which specifies their corresponding device channel.\n",
     "\n",
     "The fundamental channel types are: \n",
-    "- `DriveChannel`: Qubit drive channel. The index channel corresponds to the system qubit index.\n",
+    "- `DriveChannel`: Qubit drive channel. The channel index corresponds to the system qubit index.\n",
     "- `MeasureChannel`: Qubit stimulus channel. The channel index corresponds to the system qubit index.\n",
     "- `ControlChannel`: Arbitrary control channel with action specified by Hamiltonian provided by device. The function of this channel must be extracted from the system Hamiltonian.\n",
     "- `AcquireChannel`: Qubit acquisition channel. The channel index corresponds to the system qubit index.\n",

--- a/qiskit/fundamentals/2_plotting_data_in_qiskit.ipynb
+++ b/qiskit/fundamentals/2_plotting_data_in_qiskit.ipynb
@@ -211,7 +211,7 @@
    "source": [
     "### Sorting counts by distance from target state\n",
     "\n",
-    "Suppose you have an algorithm that encodes the solution into a single bit-string, ex. `1011`.  When running on a real quantum device, unavoidable (but sometimes correctable) noise can corrupt the answer.  The effect of the noise if often better seen if we sort the output bit-strings as a function of some 'distance' from the target bit string.  The `plot_histogram` function supports the `hamming` distance metric as demonstrated below:"
+    "Suppose you have an algorithm that encodes the solution into a single bit-string, ex. `1011`.  When running on a real quantum device, unavoidable (but sometimes correctable) noise can corrupt the answer.  The effect of the noise is often better seen if we sort the output bit-strings as a function of some 'distance' from the target bit string.  The `plot_histogram` function supports the `hamming` distance metric as demonstrated below:"
    ]
   },
   {

--- a/qiskit/fundamentals/2_plotting_data_in_qiskit.ipynb
+++ b/qiskit/fundamentals/2_plotting_data_in_qiskit.ipynb
@@ -74,7 +74,7 @@
     "\n",
     "`plot_histogram(data)`\n",
     "\n",
-    "As an example we make a 2 qubit Bell state"
+    "As an example we make a 2-qubit Bell state"
    ]
   },
   {
@@ -170,7 +170,7 @@
     }
    ],
    "source": [
-    "# Execute 2 qubit Bell state again\n",
+    "# Execute 2-qubit Bell state again\n",
     "second_result = execute(circ, backend, shots=1000).result()\n",
     "second_counts  = second_result.get_counts(circ)\n",
     "# Plot results with legend\n",

--- a/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
+++ b/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
@@ -422,7 +422,7 @@
     "\n",
     "Several of the circuit properties introduced so far change when adding classical registers and measurements.\n",
     "\n",
-    "Lets add measurements to the circuit above."
+    "Let's add measurements to the circuit above."
    ]
   },
   {

--- a/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
+++ b/qiskit/fundamentals/4_quantum_circuit_properties.ipynb
@@ -360,7 +360,7 @@
    "source": [
     "## Unitary Factors <a name=\"unitary\"></a>\n",
     "\n",
-    "The circuit we are focusing on here is a 12 qubit circuit.  However, does this circuit actually require a 12 qubit quantum computer to run?  That is to say, can we compute  the same result by running a collection of smaller circuits individually?\n",
+    "The circuit we are focusing on here is a 12-qubit circuit.  However, does this circuit actually require a 12-qubit quantum computer to run?  That is to say, can we compute  the same result by running a collection of smaller circuits individually?\n",
     "\n",
     "In the limit where only single-qubit gates are performed, it should be clear that each qubit is controlled independently of the rest, and thus we can run each qubit independently and still get the desired result.  Thus, the question becomes are there enough entangling gates in the circuit to have all qubits interacting?  Again, this is best understood in terms of diagrams.  Below, we track the sets of qubits that interact amongst themselves via CNOT gates at each layer in the circuit."
    ]
@@ -386,7 +386,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that at the end of the computation there are three independent sets of qubits.  Thus, our 12 qubit computation is actual two two qubit calculations and a single eight qubit computation.  We can verify this via qiskit:"
+    "We can see that at the end of the computation there are three independent sets of qubits.  Thus, our 12-qubit computation is actual two two-qubit calculations and a single eight-qubit computation.  We can verify this via qiskit:"
    ]
   },
   {

--- a/qiskit/fundamentals/5_using_the_transpiler.ipynb
+++ b/qiskit/fundamentals/5_using_the_transpiler.ipynb
@@ -477,7 +477,7 @@
    "source": [
     "### Toffoli Gate Decomposition\n",
     "\n",
-    "A Toffoli, or controlled-controlled-not gate, is a three qubit gate.  Given that our basis gate set includes only single- and two-qubit gates, it is obvious that this gate must be decomposed.  This decomposition is quite costly."
+    "A Toffoli, or controlled-controlled-not gate, is a three-qubit gate.  Given that our basis gate set includes only single- and two-qubit gates, it is obvious that this gate must be decomposed.  This decomposition is quite costly."
    ]
   },
   {
@@ -1476,7 +1476,7 @@
    "source": [
     "If it is possible to perform CNOT gates in both directions on all pairs of qubits, then this matrix is symmetric.\n",
     "\n",
-    "We are free to construct our own device topology by defining our own `coupling_map` and using it in `transpile`.  For example, a five qubit linear nearest-neighbor (LNN) topology supporting bi-directional CNOT gates is written as:"
+    "We are free to construct our own device topology by defining our own `coupling_map` and using it in `transpile`.  For example, a five-qubit linear nearest-neighbor (LNN) topology supporting bi-directional CNOT gates is written as:"
    ]
   },
   {
@@ -1562,7 +1562,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or we can write a directional five qubit '+' shaped topology, with all directional CNOT gates pointing to the center as:"
+    "Or we can write a directional five-qubit '+' shaped topology, with all directional CNOT gates pointing to the center as:"
    ]
   },
   {

--- a/qiskit/fundamentals/7_summary_of_quantum_operations.ipynb
+++ b/qiskit/fundamentals/7_summary_of_quantum_operations.ipynb
@@ -1327,7 +1327,7 @@
     "\n",
     "### Mathematical Preliminaries\n",
     "\n",
-    "The space of a quantum computer grows exponential with the number of qubits. For $n$ qubits the complex vector space has dimensions $d=2^n$. To describe states of a multi-qubit system, the tensor product is used to \"glue together\" operators and basis vectors.\n",
+    "The space of a quantum computer grows exponentially with the number of qubits. For $n$ qubits the complex vector space has dimension $d=2^n$. To describe states of a multi-qubit system, the tensor product is used to \"glue together\" operators and basis vectors.\n",
     "\n",
     "Let's start by considering a 2-qubit system. Given two operators $A$ and $B$ that each act on one qubit, the joint operator $A \\otimes B$ acting on two qubits is\n",
     "\n",
@@ -2407,7 +2407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Non unitary operations <a name=\"non_unitary\"/>\n",
+    "## Non-unitary operations <a name=\"non_unitary\"/>\n",
     "\n",
     "Now that we have gone through all the unitary operations in quantum circuits, we also have access to non-unitary operations. These include measurements, reset of qubits, and classical conditional operations."
    ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This fixes a number of minor typos I found while reading the notebooks, including hyphenating "[number]-qubit" when it is a compound adjective.

### Details and comments

The typos fixed are listed in the commit.

The notebooks still aren't completely consistent in that it's "two-qubit" in some places and "2-qubit" in others, but I left that alone.

(Also, I don't know where the "CHANGELOG" is that I'm supposed to add this to?)
