### PR TITLE
get gate lengths directly from backend

### DIFF
--- a/qiskit/advanced/aer/2_device_noise_simulation.ipynb
+++ b/qiskit/advanced/aer/2_device_noise_simulation.ipynb
@@ -102,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use the `ibmq_16_melbourne` device for this tutorial. We may get the properties of the backend using the `properties` method, the information in the returned `BackendProperties` object will be used to automatically generate a noise model for the device that can be used by the Qiskit Aer `QasmSimulator`. We will also want to get the `coupling_map` for the device from its `configuration` to use when compiling circuits for simulation to most closely mimic the gates that will be executed on a real device."
+    "We will use the `ibmq_essex` device for this tutorial. We may get the properties of the backend using the `properties` method, the information in the returned `BackendProperties` object will be used to automatically generate a noise model for the device that can be used by the Qiskit Aer `QasmSimulator`. We will also want to get the `coupling_map` for the device from its `configuration` to use when compiling circuits for simulation to most closely mimic the gates that will be executed on a real device."
    ]
   },
   {
@@ -189,9 +189,7 @@
     "\n",
     "For the readout errors the probability that the recorded classical bit value will be flipped from the true outcome after a measurement is given by the qubit `readout_errors`.\n",
     "\n",
-    "Let us construct the device noise model.\n",
-    "\n",
-    "**Note:** *Since the devices don't currently provide the gate times for gates we will manually provide them for the gates we are interested in using with the optional `gate_times` argument for `basic_device_noise_model`.*"
+    "Let us construct the device noise model.\n"
    ]
   },
   {
@@ -214,33 +212,11 @@
       "  Qubits with noise: [0, 1, 2, 3, 4]\n",
       "  Specific qubit errors: [('id', [0]), ('id', [1]), ('id', [2]), ('id', [3]), ('id', [4]), ('u2', [0]), ('u2', [1]), ('u2', [2]), ('u2', [3]), ('u2', [4]), ('u3', [0]), ('u3', [1]), ('u3', [2]), ('u3', [3]), ('u3', [4]), ('cx', [0, 1]), ('cx', [1, 0]), ('cx', [1, 2]), ('cx', [1, 3]), ('cx', [2, 1]), ('cx', [3, 1]), ('cx', [3, 4]), ('cx', [4, 3]), ('measure', [0]), ('measure', [1]), ('measure', [2]), ('measure', [3]), ('measure', [4])]\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\PaulNation\\Anaconda3\\lib\\site-packages\\qiskit\\providers\\aer\\noise\\device\\models.py:114: DeprecationWarning: gate_times kwarg is deprecated and will be removed in a future release. Use gate_lengths kwarg instead.\n",
-      "  DeprecationWarning)\n"
-     ]
     }
    ],
    "source": [
-    "# List of gate times for ibmq_14_melbourne device\n",
-    "# Note that the None parameter for u1, u2, u3 is because gate\n",
-    "# times are the same for all qubits\n",
-    "gate_times = [\n",
-    "    ('u1', None, 0), ('u2', None, 100), ('u3', None, 200),\n",
-    "    ('cx', [1, 0], 678), ('cx', [1, 2], 547), ('cx', [2, 3], 721),\n",
-    "    ('cx', [4, 3], 733), ('cx', [4, 10], 721), ('cx', [5, 4], 800),\n",
-    "    ('cx', [5, 6], 800), ('cx', [5, 9], 895), ('cx', [6, 8], 895),\n",
-    "    ('cx', [7, 8], 640), ('cx', [9, 8], 895), ('cx', [9, 10], 800),\n",
-    "    ('cx', [11, 10], 721), ('cx', [11, 3], 634), ('cx', [12, 2], 773),\n",
-    "    ('cx', [13, 1], 2286), ('cx', [13, 12], 1504), ('cx', [], 800)\n",
-    "]\n",
-    "\n",
     "# Construct the noise model from backend properties\n",
-    "# and custom gate times\n",
-    "noise_model = noise.device.basic_device_noise_model(properties, gate_times=gate_times)\n",
+    "noise_model = noise.device.basic_device_noise_model(properties)\n",
     "print(noise_model)"
    ]
   },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

automatic gate length inference and melbourne reference removal

### Details and comments

getting gate lengths directly from backend is now supported on all devices, so i removed the use of gate_times (which was deprecated in favor of gate_lengths anyway in the case that someone wants to manually specify the gate lengths)

i also removed a stray reference to Melbourne since it appears this was most recently run on Essex.

